### PR TITLE
138 export import use curr list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -22,6 +22,8 @@ public abstract class ImportCommand extends CommandWithFile {
     public static final String MESSAGE_FORMAT_FAILURE = "Import %s failed to recognize the file. "
             + "The csv file provided is incorrectly formatted.";
 
+    public static final String MESSAGE_DUPLICATE = "AddressBook after importing contains duplicates.";
+
     public static final String MESSAGE_SUCCESS = "Successfully imported %s.";
 
 }

--- a/src/main/java/seedu/address/logic/commands/buyer/ImportBuyersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/buyer/ImportBuyersCommand.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
+import seedu.address.model.property.exceptions.DuplicateBuyerException;
 import seedu.address.storage.Storage;
 
 /**
@@ -26,6 +27,8 @@ public class ImportBuyersCommand extends ImportCommand {
             return new CommandResult(String.format(MESSAGE_IO_FAILURE, BUYERS));
         } catch (ParseException pe) {
             return new CommandResult(String.format(MESSAGE_FORMAT_FAILURE, BUYERS) + "\n" + pe.getMessage());
+        } catch (DuplicateBuyerException dbe) {
+            return new CommandResult(String.format(MESSAGE_DUPLICATE));
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/property/ImportPropertiesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/property/ImportPropertiesCommand.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
+import seedu.address.model.property.exceptions.DuplicatePropertyException;
 import seedu.address.storage.Storage;
 
 /**
@@ -26,6 +27,8 @@ public class ImportPropertiesCommand extends ImportCommand {
             return new CommandResult(String.format(MESSAGE_IO_FAILURE, PROPERTIES));
         } catch (ParseException pe) {
             return new CommandResult(String.format(MESSAGE_FORMAT_FAILURE, PROPERTIES) + "\n" + pe.getMessage());
+        } catch (DuplicatePropertyException dpe) {
+            return new CommandResult(String.format(MESSAGE_DUPLICATE));
         }
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -160,6 +160,15 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Adds a list of properties to the address book.
+     * The properties must not already exist in the address book.
+     */
+    public void addAllProperties(List<Property> p) {
+        properties.addAll(p);
+        currProperties.addAll(p);
+    }
+
+    /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      */
@@ -207,6 +216,15 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void addNewBuyer(Buyer b) {
         buyers.addFront(b);
         currBuyers.addFront(b);
+    }
+
+    /**
+     * Adds a list of buyers to the address book.
+     * The buyers must not already exist in the address book.
+     */
+    public void addAllBuyers(List<Buyer> b) {
+        buyers.addAll(b);
+        currBuyers.addAll(b);
     }
 
     /**

--- a/src/main/java/seedu/address/model/property/UniqueBuyerList.java
+++ b/src/main/java/seedu/address/model/property/UniqueBuyerList.java
@@ -44,6 +44,15 @@ public class UniqueBuyerList extends UniqueList<Buyer> {
     }
 
     @Override
+    public void addAll(List<Buyer> toAdd) {
+        try {
+            super.addAll(toAdd);
+        } catch (DuplicateListableException e) {
+            throw new DuplicateBuyerException();
+        }
+    }
+
+    @Override
     public void remove(Buyer toRemove) {
         try {
             super.remove(toRemove);

--- a/src/main/java/seedu/address/model/property/UniqueList.java
+++ b/src/main/java/seedu/address/model/property/UniqueList.java
@@ -65,6 +65,22 @@ public class UniqueList<Item extends Listable> implements Iterable<Item> {
     }
 
     /**
+     * Adds a collection of elements to front of the list.
+     */
+    public void addAll(List<Item> toAdd) {
+        requireNonNull(toAdd);
+        if (!listablesAreUnique(toAdd)) {
+            throw new DuplicateListableException();
+        }
+        for (Item item: toAdd) {
+            if (contains(item)) {
+                throw new DuplicateListableException();
+            }
+        }
+        internalList.addAll(0, toAdd);
+    }
+
+    /**
      * Replaces the element {@code target} in the list with {@code editedListable}.
      * {@code target} must exist in the list.
      * The element identity of {@code editedListable} must not be the same as another existing element in the list.

--- a/src/main/java/seedu/address/model/property/UniquePropertyList.java
+++ b/src/main/java/seedu/address/model/property/UniquePropertyList.java
@@ -44,6 +44,15 @@ public class UniquePropertyList extends UniqueList<Property> {
     }
 
     @Override
+    public void addAll(List<Property> toAdd) {
+        try {
+            super.addAll(toAdd);
+        } catch (DuplicateListableException e) {
+            throw new DuplicatePropertyException();
+        }
+    }
+
+    @Override
     public void remove(Property toRemove) {
         try {
             super.remove(toRemove);

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -75,7 +75,7 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
         requireAllNonNull(file, addressBook);
         List<Property> properties = CsvManager.importProperties(file);
         AddressBook newAddressBook = new AddressBook(addressBook);
-        newAddressBook.setAllProperties(properties);
+        newAddressBook.addAllProperties(properties);
         return newAddressBook;
     }
 
@@ -92,7 +92,7 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
         requireAllNonNull(file, addressBook);
         List<Buyer> buyers = CsvManager.importBuyers(file);
         AddressBook newAddressBook = new AddressBook(addressBook);
-        newAddressBook.setAllBuyers(buyers);
+        newAddressBook.addAllBuyers(buyers);
         return newAddressBook;
     }
 }


### PR DESCRIPTION
For consistency, we will change it to
Export: only exports visible items
Import: imports and prepends to currList

Note: addressBook throws error message of "AddressBook after importing contains duplicates." if there are duplicates caused by importing.
Closes #138 