### PR TITLE
Fix findcommand userguide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -228,9 +228,9 @@ Format: `stat [(property | buyer)]`
 * Entering another `stat` command while the existing one is open  replaces the view in the pop-up window.
 * If only buyers or only properties are visible, `stat` automatically presents the only buyers/only properties view.
 
-### Locating properties by name: `find`
+### Locating properties/buyers by name, tags, price: `find`
 
-Finds properties or buyers whose names contain any of the given keywords and whose tag list contain all of the specified tags in the **currently displayed list**.
+Finds properties or buyers whose names contain any of the given keywords, whose tag list contain all of the specified tags and whose price is within the specified price range in the **currently displayed list**.
 
 Format: `find (properties | buyers) [KEYWORDS] [t/TAG_TO_MATCH]… [$min/MIN_PRICE] [$max/MAX_PRICE]`
 


### PR DESCRIPTION
Fix this issue in user guide:
![image](https://user-images.githubusercontent.com/51410656/139239302-834331d3-bc6e-4b99-9bf2-990b3d445eb6.png)


The updated user guide can be found here: https://lizchow.github.io/tp/UserGuide.html#locating-propertiesbuyers-by-name-tags-and-price-find